### PR TITLE
fix: let 'make style' can exit when get error

### DIFF
--- a/make/golang.mk
+++ b/make/golang.mk
@@ -76,7 +76,7 @@ go.style:
 	@$(MAKE) format && \
 		git status && \
 		[[ -z `git status -s` ]] || \
-		echo -e "\n${RED_COLOR}Error: there are uncommitted changes after formatting go codes.\n${GREEN_COLOR}You should run 'make format' then use git to commit all those changes.${NO_COLOR}"
+		(echo -e "\n${RED_COLOR}Error: there are uncommitted changes after formatting go codes.\n${GREEN_COLOR}You should run 'make format' then use git to commit all those changes.${NO_COLOR}" && exit 1)
 
 .PHONY: go.format.verify
 go.format.verify:


### PR DESCRIPTION
<!--
🎉 感谢您发送的 PR！以下是一些提示：
1、请在提交PR之前使用“make format” 格式化您的代码
2、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
3、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
make target `style` can exit when get error in running.

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
No issue.

#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
Nothing.